### PR TITLE
fix: Prebuilt Lambda 404 errors

### DIFF
--- a/lambda/install.js
+++ b/lambda/install.js
@@ -9,7 +9,7 @@ const pipeline = promisify(stream.pipeline);
 
 const package = require('../package.json');
 const version = package.version;
-const rootUrl = package.repository.url;
+const rootUrl = package.repository.url.replace('git+', '').replace('.git', '');
 
 function mkdirp(p) {
   if (!fs.existsSync(p)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,8 @@ export interface IImageName {
 }
 
 function getCode(): lambda.AssetCode {
-  if (!(process.env.CI || process.env.NO_PREBUILT_LAMBDA)) {
+  const { CI, NO_PREBUILT_LAMBDA } = process.env;
+  if (!(CI && ['true', true, 1, '1'].includes(CI)) || (NO_PREBUILT_LAMBDA && ['true', true, 1, '1'].includes(NO_PREBUILT_LAMBDA))) {
     try {
       console.log('Try to get prebuilt lambda');
 


### PR DESCRIPTION
Fixes # Prebuilt Lambda 404 errors

The `package.json` `repository` value reverts to the `git+https://github.com/cdklabs/cdk-ecr-deployment` value during publish. When referencing the `resposotory.url` value in `lambda/instal.js`  replace `git+` and `.git` with blanks.

`process.env.CI` and `process.env.NO_PREBUILT_LAMBDA` are string values. Passing `CI=false` or `NO_PREBUILT_LAMBDA=0` will skip the attempt to download the rebuilt lambda as either of those two values will will exists as strings. When referencing these values in `src/index.ts`, check truthy against `'true', true, 1, '1'` to handle strings and boolean values.