### PR TITLE
feat: optimize bin install script

### DIFF
--- a/lambda/install.js
+++ b/lambda/install.js
@@ -46,18 +46,18 @@ async function download(url, dest) {
   }
   mkdirp(dir);
 
-  const expectedIntegrity = (await got(`${rootUrl}/releases/download/v${version}/main.sha256`)).body.trim();
   const bin = path.join(dir, 'main');
 
   if (!fs.existsSync(bin)) {
     await download(`${rootUrl}/releases/download/v${version}/main`, bin);
+    const expectedIntegrity = (await got(`${rootUrl}/releases/download/v${version}/main.sha256`)).body.trim();
+    const integrity = await sha256sum(bin);
+
+    if (integrity !== expectedIntegrity) {
+      throw new Error(`Integrity check error: expected ${expectedIntegrity} but got ${integrity}`);
+    }
   }
 
-  const integrity = await sha256sum(bin);
-
-  if (integrity !== expectedIntegrity) {
-    throw new Error(`Integrity check error: expected ${expectedIntegrity} but got ${integrity}`);
-  }
 })().catch(err => {
   console.error(err.toString());
   process.exit(1);


### PR DESCRIPTION
This optimizes the `lambda/install.js` script by executing the bin download and integrity check just once (only if the bin file does not exist yet).

This helps improving CDK app synth performances when multiple stacks / resources use the `ECRDeployment` construct.