### PR TITLE
fix: passing environment variables to child process (#180)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,9 @@ function getCode(buildImage: string): lambda.AssetCode {
 
       const installScript = path.join(__dirname, '../lambda/install.js');
       const prebuiltPath = path.join(__dirname, '../lambda/out');
-      child_process.execSync(`${process.argv0} ${installScript} ${prebuiltPath}`);
+      child_process.execSync(`${process.argv0} ${installScript} ${prebuiltPath}`, {
+        env: process.env,
+      });
 
       return lambda.Code.fromAsset(prebuiltPath);
     } catch (err) {


### PR DESCRIPTION
Passes the environment variables of the parent process to the created child process when running the lambda installation script to enable proxy usage when downloading current code of lambda from repository.
Fixes #180 