### PR TITLE
feat: Add publishing to maven central

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -32,6 +32,12 @@ const project = new awscdk.AwsCdkConstructLibrary({
     distName: 'cdk-ecr-deployment',
     module: 'cdk_ecr_deployment',
   }, /* Publish to pypi. */
+  publishToMaven: {
+    mavenGroupId: 'io.github.cdklabs',
+    mavenArtifactId: 'cdk-ecr-deployment',
+    javaPackage: 'io.github.cdklabs.cdkecrdeployment',
+    mavenEndpoint: 'https://s01.oss.sonatype.org',
+  }, /* Publish to maven central. */
   bundledDeps: [
     'got',
     'hpagent',

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Release](https://github.com/cdklabs/cdk-ecr-deployment/actions/workflows/release.yml/badge.svg)](https://github.com/cdklabs/cdk-ecr-deployment/actions/workflows/release.yml)
 [![npm version](https://img.shields.io/npm/v/cdk-ecr-deployment)](https://www.npmjs.com/package/cdk-ecr-deployment)
 [![PyPI](https://img.shields.io/pypi/v/cdk-ecr-deployment)](https://pypi.org/project/cdk-ecr-deployment)
+[![Maven version](https://img.shields.io/maven-central/v/io.github.cdklabs/cdk-ecr-deployment)](https://search.maven.org/search?q=a:cdk-ecr-deployment)
 [![npm](https://img.shields.io/npm/dw/cdk-ecr-deployment?label=npm%20downloads)](https://www.npmjs.com/package/cdk-ecr-deployment)
 [![PyPI - Downloads](https://img.shields.io/pypi/dw/cdk-ecr-deployment?label=pypi%20downloads)](https://pypi.org/project/cdk-ecr-deployment)
 


### PR DESCRIPTION
This PR adds support for using for cdk-ecr-deployment in Java based project. To be able to do so we need publishing to maven central in a similar way that is done for `cdk-nag`.

Fixes #203