### PR TITLE
fix: lambda release

### DIFF
--- a/.github/workflows/release-v1-main.yml
+++ b/.github/workflows/release-v1-main.yml
@@ -267,11 +267,11 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: build-artifact
-          path: dist
+          path: .repo
       - name: Build lambda
         run: docker build -t cdk-ecr-deployment-lambda --build-arg _GOPROXY="https://goproxy.io|https://goproxy.cn|direct" lambda && docker run -v $PWD/lambda:/out cdk-ecr-deployment-lambda cp /asset/main /out && echo $(sha256sum lambda/main | awk '{ print $1 }') > lambda/main.sha256
       - name: Release lambda
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: "gh release upload -R $GITHUB_REPOSITORY v$(cat dist/version.txt) lambda/main lambda/main.sha256 "
+        run: "gh release upload -R $GITHUB_REPOSITORY v$(cat .repo/dist/version.txt) lambda/main lambda/main.sha256 "

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,11 +267,11 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: build-artifact
-          path: dist
+          path: .repo
       - name: Build lambda
         run: docker build -t cdk-ecr-deployment-lambda --build-arg _GOPROXY="https://goproxy.io|https://goproxy.cn|direct" lambda && docker run -v $PWD/lambda:/out cdk-ecr-deployment-lambda cp /asset/main /out && echo $(sha256sum lambda/main | awk '{ print $1 }') > lambda/main.sha256
       - name: Release lambda
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: "gh release upload -R $GITHUB_REPOSITORY v$(cat dist/version.txt) lambda/main lambda/main.sha256 "
+        run: "gh release upload -R $GITHUB_REPOSITORY v$(cat .repo/dist/version.txt) lambda/main lambda/main.sha256 "

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -68,7 +68,7 @@ project.release?.addJobs({
         uses: 'actions/download-artifact@v2',
         with: {
           name: 'build-artifact',
-          path: 'dist',
+          path: '.repo',
         },
       },
       {
@@ -81,7 +81,7 @@ project.release?.addJobs({
       },
       {
         name: 'Release lambda',
-        run: 'gh release upload -R $GITHUB_REPOSITORY v$(cat dist/version.txt) lambda/main lambda/main.sha256 ',
+        run: 'gh release upload -R $GITHUB_REPOSITORY v$(cat .repo/dist/version.txt) lambda/main lambda/main.sha256 ',
         env: {
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
           GITHUB_REPOSITORY: '${{ github.repository }}',


### PR DESCRIPTION
The artifact is downloaded to the `.repo` directory and contains the version in a file at `dist/version.txt`.
