### PR TITLE
chore: release to GitHub always fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,4 +274,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: "gh release upload -R $GITHUB_REPOSITORY v$(cat .repo/dist/version.txt) lambda/main lambda/main.sha256 "
+        run: "gh release upload --clobber -R $GITHUB_REPOSITORY v$(cat .repo/dist/version.txt) lambda/main lambda/main.sha256 "

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -82,7 +82,9 @@ project.release?.addJobs({
       },
       {
         name: 'Release lambda',
-        run: 'gh release upload -R $GITHUB_REPOSITORY v$(cat .repo/dist/version.txt) lambda/main lambda/main.sha256 ',
+        // For some reason, need '--clobber' otherwise we always get errors that these files already exist. They're probably
+        // uploaded elsewhere but TBH I don't know where so just add this flag to make it not fail.
+        run: 'gh release upload --clobber -R $GITHUB_REPOSITORY v$(cat .repo/dist/version.txt) lambda/main lambda/main.sha256 ',
         env: {
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
           GITHUB_REPOSITORY: '${{ github.repository }}',


### PR DESCRIPTION
GitHub always complains that the files we try to attach to the release already exist. Add the `--clobber` flag to overwrite, which will stop the error.

(I'm not quite sure why the files are already there, and it seems to be inconsistent as well. But this will at least fix the error.)

Fixes #