### PR TITLE
fix: Use Amazon Linux 2 provided runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,7 +269,7 @@ jobs:
           name: build-artifact
           path: .repo
       - name: Build lambda
-        run: docker build -t cdk-ecr-deployment-lambda --build-arg _GOPROXY="https://goproxy.io|https://goproxy.cn|direct" lambda && docker run -v $PWD/lambda:/out cdk-ecr-deployment-lambda cp /asset/main /out && echo $(sha256sum lambda/main | awk '{ print $1 }') > lambda/main.sha256
+        run: docker build -t cdk-ecr-deployment-lambda --build-arg _GOPROXY="https://goproxy.io|https://goproxy.cn|direct" lambda && docker run -v $PWD/lambda:/out cdk-ecr-deployment-lambda cp /asset/bootstrap /out && echo $(sha256sum lambda/main | awk '{ print $1 }') > lambda/bootstrap.sha256
       - name: Release lambda
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,7 +269,7 @@ jobs:
           name: build-artifact
           path: .repo
       - name: Build lambda
-        run: docker build -t cdk-ecr-deployment-lambda --build-arg _GOPROXY="https://goproxy.io|https://goproxy.cn|direct" lambda && docker run -v $PWD/lambda:/out cdk-ecr-deployment-lambda cp /asset/bootstrap /out && echo $(sha256sum lambda/main | awk '{ print $1 }') > lambda/bootstrap.sha256
+        run: docker build -t cdk-ecr-deployment-lambda --build-arg GOPROXY="https://goproxy.io|https://goproxy.cn|direct" lambda && docker run -v $PWD/lambda:/out cdk-ecr-deployment-lambda cp /asset/bootstrap /out && echo $(sha256sum lambda/main | awk '{ print $1 }') > lambda/bootstrap.sha256
       - name: Release lambda
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,4 +274,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: "gh release upload --clobber -R $GITHUB_REPOSITORY v$(cat .repo/dist/version.txt) lambda/main lambda/main.sha256 "
+        run: "gh release upload --clobber -R $GITHUB_REPOSITORY v$(cat .repo/dist/version.txt) lambda/bootstrap lambda/bootstrap.sha256 "

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,7 +269,7 @@ jobs:
           name: build-artifact
           path: .repo
       - name: Build lambda
-        run: docker build -t cdk-ecr-deployment-lambda --build-arg GOPROXY="https://goproxy.io|https://goproxy.cn|direct" lambda && docker run -v $PWD/lambda:/out cdk-ecr-deployment-lambda cp /asset/bootstrap /out && echo $(sha256sum lambda/main | awk '{ print $1 }') > lambda/bootstrap.sha256
+        run: docker build -t cdk-ecr-deployment-lambda --build-arg GOPROXY="https://goproxy.io|https://goproxy.cn|direct" lambda && docker run -v $PWD/lambda:/out cdk-ecr-deployment-lambda cp /asset/bootstrap /out && echo $(sha256sum lambda/bootstrap | awk '{ print $1 }') > lambda/bootstrap.sha256
       - name: Release lambda
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -269,7 +269,7 @@
       "description": "Prepare a release from \"main\" branch",
       "env": {
         "RELEASE": "true",
-        "MAJOR": "2"
+        "MAJOR": "3"
       },
       "steps": [
         {
@@ -348,7 +348,7 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=prod --filter=aws-cdk-lib,constructs,got,hpagent"
+          "exec": "npx npm-check-updates@latest --upgrade --target=minor --peer --dep=prod,peer --filter=aws-cdk-lib,constructs,got,hpagent"
         },
         {
           "exec": "yarn install --check-files"
@@ -372,7 +372,7 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen"
+          "exec": "npx npm-check-updates@latest --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen"
         },
         {
           "exec": "yarn install --check-files"
@@ -396,13 +396,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest,jest-junit,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,projen,standard-version,ts-jest,ts-node,typescript"
+          "exec": "npx npm-check-updates@latest --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest,jest-junit,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,npm-check-updates,projen,standard-version,ts-jest,ts-node,typescript"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta projen standard-version ts-jest ts-node typescript"
+          "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta npm-check-updates projen standard-version ts-jest ts-node typescript"
         },
         {
           "exec": "npx projen"

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -348,7 +348,7 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@latest --upgrade --target=minor --peer --dep=prod,peer --filter=aws-cdk-lib,constructs,got,hpagent"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=prod --filter=aws-cdk-lib,constructs,got,hpagent"
         },
         {
           "exec": "yarn install --check-files"
@@ -372,7 +372,7 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@latest --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen"
+          "exec": "npx npm-check-updates@16 --upgrade --target=latest --peer --dep=dev,peer,prod,optional --filter=cdklabs-projen-project-types,projen"
         },
         {
           "exec": "yarn install --check-files"
@@ -396,13 +396,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@latest --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest,jest-junit,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,npm-check-updates,projen,standard-version,ts-jest,ts-node,typescript"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,cdklabs-projen-project-types,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest,jest-junit,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,projen,standard-version,ts-jest,ts-node,typescript"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta npm-check-updates projen standard-version ts-jest ts-node typescript"
+          "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta projen standard-version ts-jest ts-node typescript"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -13,7 +13,7 @@ const project = new CdklabsConstructLibrary({
   cdkVersion: '2.0.0',
   cdkVersionPinning: false,
   defaultReleaseBranch: 'main',
-  majorVersion: 2,
+  majorVersion: 3,
   enablePRAutoMerge: true,
   name: 'cdk-ecr-deployment',
   projenrcTs: true,

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -75,7 +75,7 @@ project.release?.addJobs({
       {
         name: 'Build lambda',
         run: [
-          'docker build -t cdk-ecr-deployment-lambda --build-arg _GOPROXY="https://goproxy.io|https://goproxy.cn|direct" lambda',
+          'docker build -t cdk-ecr-deployment-lambda --build-arg GOPROXY="https://goproxy.io|https://goproxy.cn|direct" lambda',
           'docker run -v $PWD/lambda:/out cdk-ecr-deployment-lambda cp /asset/bootstrap /out',
           'echo $(sha256sum lambda/bootstrap | awk \'{ print $1 }\') > lambda/bootstrap.sha256',
         ].join(' && '),

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -76,15 +76,15 @@ project.release?.addJobs({
         name: 'Build lambda',
         run: [
           'docker build -t cdk-ecr-deployment-lambda --build-arg _GOPROXY="https://goproxy.io|https://goproxy.cn|direct" lambda',
-          'docker run -v $PWD/lambda:/out cdk-ecr-deployment-lambda cp /asset/main /out',
-          'echo $(sha256sum lambda/main | awk \'{ print $1 }\') > lambda/main.sha256',
+          'docker run -v $PWD/lambda:/out cdk-ecr-deployment-lambda cp /asset/bootstrap /out',
+          'echo $(sha256sum lambda/bootstrap | awk \'{ print $1 }\') > lambda/bootstrap.sha256',
         ].join(' && '),
       },
       {
         name: 'Release lambda',
         // For some reason, need '--clobber' otherwise we always get errors that these files already exist. They're probably
         // uploaded elsewhere but TBH I don't know where so just add this flag to make it not fail.
-        run: 'gh release upload --clobber -R $GITHUB_REPOSITORY v$(cat .repo/dist/version.txt) lambda/main lambda/main.sha256 ',
+        run: 'gh release upload --clobber -R $GITHUB_REPOSITORY v$(cat .repo/dist/version.txt) lambda/bootstrap lambda/bootstrap.sha256 ',
         env: {
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
           GITHUB_REPOSITORY: '${{ github.repository }}',

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Enable flags: `true`, `1`. e.g. `export CI=1`
 
 ⚠️ If you want to force using prebuilt lambda in CI environment to reduce build time. Try `export FORCE_PREBUILT_LAMBDA=1`.
 
-⚠️ The above flags are only available in cdk-ecr-deployment 2.x.
+⚠️ The above flags are only available in cdk-ecr-deployment 2.x and 3.x.
 
 ## Examples
 

--- a/lambda/.dockerignore
+++ b/lambda/.dockerignore
@@ -4,6 +4,6 @@ node_modules
 coverage
 test-reports
 **/*.md
-main
-main.sha256
+bootstrap
+bootstrap.sha256
 cdk.out

--- a/lambda/Dockerfile
+++ b/lambda/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-ARG buildImage=golang:1.21
+ARG buildImage=golang:1
 FROM ${buildImage} as build
 
 USER root

--- a/lambda/Dockerfile
+++ b/lambda/Dockerfile
@@ -5,16 +5,12 @@ FROM ${buildImage} as build
 
 USER root
 
-# In https://github.com/aws/aws-sam-build-images/blob/0a39eebc0d1d462afbe155d4e6a4cbcb12888847/build-image-src/Dockerfile-go1x#L29
-# already defined GOPROXY env.
-# To avoid naming conflict which will lead to weird error like https://github.com/laradock/laradock/issues/2618
-# , use the following name instead
-ARG _GOPROXY
+ARG GOPROXY
 
 ENV GOOS=linux \
     GOARCH=amd64 \
     GO111MODULE=on \
-    GOPROXY="${_GOPROXY}"
+    GOPROXY="${GOPROXY}"
 
 WORKDIR /ws
 

--- a/lambda/Dockerfile
+++ b/lambda/Dockerfile
@@ -1,17 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-ARG buildImage=public.ecr.aws/sam/build-go1.x:latest
-
-FROM ${buildImage}
+ARG buildImage=golang:1.21
+FROM ${buildImage} as build
 
 USER root
-
-RUN yum -y install \
-    gpgme-devel \
-    btrfs-progs-devel \
-    device-mapper-devel \
-    libassuan-devel \
-    libudev-devel
 
 # In https://github.com/aws/aws-sam-build-images/blob/0a39eebc0d1d462afbe155d4e6a4cbcb12888847/build-image-src/Dockerfile-go1x#L29
 # already defined GOPROXY env.
@@ -35,6 +27,4 @@ RUN go env
 COPY . /ws
 
 RUN mkdir -p /asset/ && \
-    make OUTPUT=/asset/main && \
-    file /asset/main && \
-    ls -lh /asset/main
+    make OUTPUT=/asset/bootstrap

--- a/lambda/Makefile
+++ b/lambda/Makefile
@@ -18,7 +18,7 @@ ifeq ($(GOOS), linux)
   endif
 endif
 
-BUILDTAGS := exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp
+BUILDTAGS := exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp lambda.norpc
 OUTPUT ?= cdk-ecr-deployment-handler
 
 all: test lambda

--- a/lambda/install.js
+++ b/lambda/install.js
@@ -52,8 +52,8 @@ async function download(url, dest, agent) {
     agent.https = process.env.HTTPS_PROXY ? new HttpsProxyAgent({proxy: process.env.HTTPS_PROXY}): undefined;
     agent.http = process.env.HTTP_PROXY ? new HttpProxyAgent({proxy: process.env.HTTP_PROXY}): undefined;
 
-    await download(`${rootUrl}/releases/download/v${version}/main`, bin, agent);
-    const expectedIntegrity = (await got(`${rootUrl}/releases/download/v${version}/main.sha256`, { agent })).body.trim();
+    await download(`${rootUrl}/releases/download/v${version}/bootstrap`, bin, agent);
+    const expectedIntegrity = (await got(`${rootUrl}/releases/download/v${version}/bootstrap.sha256`, { agent })).body.trim();
     const integrity = await sha256sum(bin);
 
     if (integrity !== expectedIntegrity) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ export class ECRDeployment extends Construct {
     const memoryLimit = props.memoryLimit ?? 512;
     this.handler = new lambda.SingletonFunction(this, 'CustomResourceHandler', {
       uuid: this.renderSingletonUuid(memoryLimit),
-      code: getCode(props.buildImage ?? 'golang:1.21'),
+      code: getCode(props.buildImage ?? 'golang:1'),
       runtime: lambda.Runtime.PROVIDED_AL2023,
       handler: 'bootstrap',
       environment: props.environment,

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,9 +139,9 @@ export class ECRDeployment extends Construct {
     const memoryLimit = props.memoryLimit ?? 512;
     this.handler = new lambda.SingletonFunction(this, 'CustomResourceHandler', {
       uuid: this.renderSingletonUuid(memoryLimit),
-      code: getCode(props.buildImage ?? 'public.ecr.aws/sam/build-go1.x:latest'),
-      runtime: lambda.Runtime.GO_1_X,
-      handler: 'main',
+      code: getCode(props.buildImage ?? 'golang:1.21'),
+      runtime: lambda.Runtime.PROVIDED_AL2023,
+      handler: 'bootstrap',
       environment: props.environment,
       lambdaPurpose: 'Custom::CDKECRDeployment',
       timeout: Duration.minutes(15),

--- a/test/lambda/Dockerfile
+++ b/test/lambda/Dockerfile
@@ -5,16 +5,12 @@ FROM ${buildImage} as build
 
 USER root
 
-# In https://github.com/aws/aws-sam-build-images/blob/0a39eebc0d1d462afbe155d4e6a4cbcb12888847/build-image-src/Dockerfile-go1x#L29
-# already defined GOPROXY env.
-# To avoid naming conflict which will lead to weird error like https://github.com/laradock/laradock/issues/2618
-# , use the following name instead
-ARG _GOPROXY
+ARG GOPROXY
 
 ENV GOOS=linux \
     GOARCH=amd64 \
     GO111MODULE=on \
-    GOPROXY="${_GOPROXY}"
+    GOPROXY="${GOPROXY}"
 
 ADD . /opt/awscli
 

--- a/test/lambda/Dockerfile
+++ b/test/lambda/Dockerfile
@@ -1,16 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-FROM public.ecr.aws/sam/build-go1.x:latest
+ARG buildImage=golang:1.21
+FROM ${buildImage} as build
 
 USER root
-
-RUN yum -y install \
-    gpgme-devel \
-    btrfs-progs-devel \
-    device-mapper-devel \
-    libassuan-devel \
-    libudev-devel
 
 # In https://github.com/aws/aws-sam-build-images/blob/0a39eebc0d1d462afbe155d4e6a4cbcb12888847/build-image-src/Dockerfile-go1x#L29
 # already defined GOPROXY env.

--- a/test/lambda/Dockerfile
+++ b/test/lambda/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-ARG buildImage=golang:1.21
+ARG buildImage=golang:1
 FROM ${buildImage} as build
 
 USER root

--- a/test/lambda/test.sh
+++ b/test/lambda/test.sh
@@ -21,4 +21,4 @@ cp -vf ${scriptdir}/* $PWD
 
 # this will run our tests inside the right environment
 docker version
-docker build --progress plain --build-arg _GOPROXY="https://goproxy.io|https://goproxy.cn|direct" .
+docker build --progress plain --build-arg GOPROXY="https://goproxy.io|https://goproxy.cn|direct" .


### PR DESCRIPTION
Breaking change: builds now expect a `golang` image. This may break set ups that have specified a particular image tag.

Fixes https://github.com/cdklabs/cdk-ecr-deployment/issues/320.

Supercedes https://github.com/cdklabs/cdk-ecr-deployment/pull/401.

As part of this change, the compiled Go binary main is renamed to bootstrap, as that is the name that the AL2023 Lambda runtime expects.

We now build using the standard Go Docker image, as the AWS Lambda Go image is deprecated.

It's important to note that the Dockerfile in the lambda/ folder is not used as part of the runtime at all. It's only function is to produce the /asset/bootstrap binary that is then uploaded to Lambda and used with the AL2023 runtime. This was the case before this change, except it used to produce /asset/main to use with the Go runtime.

I've tested this using the Sample application as documented in the README.md, using [the steps I documented in my issue about the Sample](https://github.com/cdklabs/cdk-ecr-deployment/issues/419) to make it usable.

My testing steps were:

* Deploy the Sample application using the unchanged package (using the Go runtime);
* Deploy again with this change (prove we can change from the Go runtime to AL2023 successfully);
* Update /test/docker/Dockerfile to point to an older version of Nginx, so we have a change to the deployed asset, and confirm the Sample deploys successfully, and that the asset in the nginx ECR repository the Sample application creates is updated successfully.

If you are going to try these tests yourself, I suggest that before you do the deploy to change the deployed asset, you test that the Lambda function is actually callable. I wasted a lot of time, because if the custom resource Lambda handler does not work, the rollback hangs for an hour before it fails. If you call the Lambda from the console with `{}` as the input, you should see an error similar to `{"errorMessage":"Put \"\": unsupported protocol scheme \"\"","errorType":"Error"}`. This indicates execution is getting into the Lambda handler code.

Note that both release packaging and the prebuilt Lambda functionality is affected by this change. I cannot think of a meaningful way to test these changes without actually releasing them.

Release packaging is impacted, because the build Go binary and it's hash are included in the release files. The release is updated to match the new naming, so we have `bootstrap` and `bootstrap.sha256` instead of `main` and `main.sha256`.

These release files are then used by the prebuilt Lambda functionality. When [using the prebuilt Lambda](https://github.com/cdklabs/cdk-ecr-deployment/blob/f1ce97535858ec5409e7f5bb6cd57b175d757227/src/index.ts#L98-L116), the Lambda is [downloaded from the Github release files via /lambda/install.js](https://github.com/cdklabs/cdk-ecr-deployment/blob/f1ce97535858ec5409e7f5bb6cd57b175d757227/lambda/install.js#L55-L57). This logic also had to be changed to reflect the `bootstrap` naming.

As part of this change we get rid of the `_GOPROXY` alias for `GOPROXY`, as this was only needed because of the AWS build image (as per the removed comment).