### PR TITLE
fix: update default runtime to support CDK < 2.105.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import * as child_process from 'child_process';
 import * as path from 'path';
 import { aws_ec2 as ec2, aws_iam as iam, aws_lambda as lambda, Duration, CustomResource, Token } from 'aws-cdk-lib';
 import { PolicyStatement, AddToPrincipalPolicyResult } from 'aws-cdk-lib/aws-iam';
+import { RuntimeFamily } from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 import { shouldUsePrebuiltLambda } from './config';
 
@@ -154,7 +155,7 @@ export class ECRDeployment extends Construct {
     this.handler = new lambda.SingletonFunction(this, 'CustomResourceHandler', {
       uuid: this.renderSingletonUuid(memoryLimit),
       code: getCode(props.buildImage ?? 'golang:1'),
-      runtime: props.lambdaRuntime ?? lambda.Runtime.PROVIDED_AL2023,
+      runtime: props.lambdaRuntime ?? new lambda.Runtime('provided.al2023', RuntimeFamily.OTHER), // not using Runtime.PROVIDED_AL2023 to support older CDK versions (< 2.105.0)
       handler: props.lambdaHandler ?? 'bootstrap',
       environment: props.environment,
       lambdaPurpose: 'Custom::CDKECRDeployment',


### PR DESCRIPTION
As of version 3.x, this project now uses the `Runtime.PROVIDED_AL2023` runtime. However, this enumerated value does not exist in older versions of aws-cdk, prior to `aws-cdk-lib@2.105.0`. If you use a version older than that, you get this cryptic error:

```shell
TypeError: Cannot read properties of undefined (reading 'name')
    at new Function (/home/runner/work/cdk-bug-reports/cdk-bug-reports/node_modules/aws-cdk-lib/aws-lambda/lib/function.js:1:11075)
    at SingletonFunction.ensureLambda (/home/runner/work/cdk-bug-reports/cdk-bug-reports/node_modules/aws-cdk-lib/aws-lambda/lib/singleton-lambda.js:1:2886)
    at new SingletonFunction (/home/runner/work/cdk-bug-reports/cdk-bug-reports/node_modules/aws-cdk-lib/aws-lambda/lib/singleton-lambda.js:1:866)
    at new ECRDeployment (/home/runner/work/cdk-bug-reports/cdk-bug-reports/node_modules/cdk-ecr-deployment/src/index.ts:140:20)
    at new TestCdkVersionStack (/home/runner/work/cdk-bug-reports/cdk-bug-reports/lib/test-cdk-version-stack.ts:9:5)
    at Object.<anonymous> (/home/runner/work/cdk-bug-reports/cdk-bug-reports/bin/test-cdk-version.ts:7:1)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module.m._compile (/home/runner/work/cdk-bug-reports/cdk-bug-reports/node_modules/ts-node/src/index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Object.require.extensions.<computed> [as .ts] (/home/runner/work/cdk-bug-reports/cdk-bug-reports/node_modules/ts-node/src/index.ts:1621:12)
```

Therefore, we're not using the static version, instead `new`-ing it up: https://github.com/aws/aws-cdk/blob/b49032b3a6e549783b45492ffc76880fbcd58e68/packages/aws-cdk-lib/aws-lambda/lib/runtime.ts#L300-L303