### PR TITLE
fix: Work with isolated region(s) due to different endpoints

### DIFF
--- a/lambda/utils.go
+++ b/lambda/utils.go
@@ -36,7 +36,7 @@ type ECRAuth struct {
 }
 
 func GetECRRegion(uri string) string {
-	re := regexp.MustCompile(`dkr\.ecr\.(.+?)\.amazonaws\.com`)
+	re := regexp.MustCompile(`dkr\.ecr\.(.+?)\.`)
 	m := re.FindStringSubmatch(uri)
 	if m != nil {
 		return m[1]


### PR DESCRIPTION
Fixes # n/a

Currently, if working in an isolated region in AWS, it uses different types of endpoints. Hence `amazonaws.com` will not work in and will throw `GetAuthorizationToken` because it does not exist.