### PR TITLE
chore: bump `download-artifact` to `v4`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,7 +274,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Download build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: .repo

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -66,7 +66,7 @@ project.release?.addJobs({
       },
       {
         name: 'Download build artifacts',
-        uses: 'actions/download-artifact@v2',
+        uses: 'actions/download-artifact@v4',
         with: {
           name: 'build-artifact',
           path: '.repo',


### PR DESCRIPTION
Upload and Download artifact versions need to be same. Currently, `upload-artifact@v4` is mismatching with `download-artifact@v2`. This PR is fixing that. 