### PR TITLE
feat: support different architectures when copying images

### DIFF
--- a/API.md
+++ b/API.md
@@ -75,6 +75,7 @@ new ECRDeployment(scope: Construct, id: string, props: ECRDeploymentProps)
 * **props** (<code>[ECRDeploymentProps](#cdk-ecr-deployment-ecrdeploymentprops)</code>)  *No description*
   * **dest** (<code>[IImageName](#cdk-ecr-deployment-iimagename)</code>)  The destination of the docker image. 
   * **src** (<code>[IImageName](#cdk-ecr-deployment-iimagename)</code>)  The source of the docker image. 
+  * **architecture** (<code>string</code>)  The architecture of the images to copy. Necessary if the image architecture differs from the lambda architecture. 
   * **buildImage** (<code>string</code>)  Image to use to build Golang lambda for custom resource, if download fails or is not wanted. __*Default*__: public.ecr.aws/sam/build-go1.x:latest
   * **environment** (<code>Map<string, string></code>)  The environment variable to set. __*Optional*__
   * **memoryLimit** (<code>number</code>)  The amount of memory (in MiB) to allocate to the AWS Lambda function which replicates the files from the CDK bucket to the destination bucket. __*Default*__: 512

--- a/API.md
+++ b/API.md
@@ -75,7 +75,7 @@ new ECRDeployment(scope: Construct, id: string, props: ECRDeploymentProps)
 * **props** (<code>[ECRDeploymentProps](#cdk-ecr-deployment-ecrdeploymentprops)</code>)  *No description*
   * **dest** (<code>[IImageName](#cdk-ecr-deployment-iimagename)</code>)  The destination of the docker image. 
   * **src** (<code>[IImageName](#cdk-ecr-deployment-iimagename)</code>)  The source of the docker image. 
-  * **architecture** (<code>string</code>)  The architecture of the images to copy. Necessary if the image architecture differs from the lambda architecture. 
+  * **architecture** (<code>string</code>)  The architecture of the docker images to copy. __*Optional*__
   * **buildImage** (<code>string</code>)  Image to use to build Golang lambda for custom resource, if download fails or is not wanted. __*Default*__: public.ecr.aws/sam/build-go1.x:latest
   * **environment** (<code>Map<string, string></code>)  The environment variable to set. __*Optional*__
   * **memoryLimit** (<code>number</code>)  The amount of memory (in MiB) to allocate to the AWS Lambda function which replicates the files from the CDK bucket to the destination bucket. __*Default*__: 512
@@ -145,6 +145,7 @@ Name | Type | Description
 -----|------|-------------
 **dest** | <code>[IImageName](#cdk-ecr-deployment-iimagename)</code> | The destination of the docker image.
 **src** | <code>[IImageName](#cdk-ecr-deployment-iimagename)</code> | The source of the docker image.
+**architecture**? | <code>string</code> | The architecture of the docker images to copy.<br/>__*Optional*__
 **buildImage**? | <code>string</code> | Image to use to build Golang lambda for custom resource, if download fails or is not wanted.<br/>__*Default*__: public.ecr.aws/sam/build-go1.x:latest
 **environment**? | <code>Map<string, string></code> | The environment variable to set.<br/>__*Optional*__
 **memoryLimit**? | <code>number</code> | The amount of memory (in MiB) to allocate to the AWS Lambda function which replicates the files from the CDK bucket to the destination bucket.<br/>__*Default*__: 512

--- a/lambda/Dockerfile
+++ b/lambda/Dockerfile
@@ -18,9 +18,9 @@ COPY go.mod go.sum ./
 
 RUN go env
 
-# RUN go mod download -x
-
 COPY . /ws
 
 RUN mkdir -p /asset/ && \
     make OUTPUT=/asset/bootstrap
+
+ENTRYPOINT [ "/asset/bootstrap" ]

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -71,7 +71,12 @@ func handler(ctx context.Context, event cfn.Event) (physicalResourceID string, d
 			return physicalResourceID, data, err
 		}
 
-		log.Printf("SrcImage: %v DestImage: %v", srcImage, destImage)
+		arch, err := getStrPropsDefault(event.ResourceProperties, ARCHITECTURE, "")
+		if err != nil {
+			return physicalResourceID, data, err
+		}
+
+		log.Printf("SrcImage: %v DestImage: %v Architecture: %v", srcImage, destImage, arch)
 
 		srcRef, err := alltransports.ParseImageName(srcImage)
 		if err != nil {
@@ -82,13 +87,13 @@ func handler(ctx context.Context, event cfn.Event) (physicalResourceID string, d
 			return physicalResourceID, data, err
 		}
 
-		srcOpts := NewImageOpts(srcImage)
+		srcOpts := NewImageOpts(srcImage, arch)
 		srcOpts.SetCreds(srcCreds)
 		srcCtx, err := srcOpts.NewSystemContext()
 		if err != nil {
 			return physicalResourceID, data, err
 		}
-		destOpts := NewImageOpts(destImage)
+		destOpts := NewImageOpts(destImage, arch)
 		destOpts.SetCreds(destCreds)
 		destCtx, err := destOpts.NewSystemContext()
 		if err != nil {

--- a/lambda/main_test.go
+++ b/lambda/main_test.go
@@ -33,10 +33,10 @@ func TestMain(t *testing.T) {
 	destRef, err := alltransports.ParseImageName(destImage)
 	assert.NoError(t, err)
 
-	srcOpts := NewImageOpts(srcImage)
+	srcOpts := NewImageOpts(srcImage, "arm64")
 	srcCtx, err := srcOpts.NewSystemContext()
 	assert.NoError(t, err)
-	destOpts := NewImageOpts(destImage)
+	destOpts := NewImageOpts(destImage, "arm64")
 	destCtx, err := destOpts.NewSystemContext()
 	assert.NoError(t, err)
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   ],
   "main": "lib/index.js",
   "license": "Apache-2.0",
-  "version": "0.0.0",
+  "version": "3.0.0",
   "jest": {
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.ts?(x)",

--- a/publish-ark-image.sh
+++ b/publish-ark-image.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+ECR_URI="758920976184.dkr.ecr.us-east-1.amazonaws.com"
+ECR_REPO_URI=$ECR_URI/cdk-ecr-deployment
+# Authenticate with AWS ECR
+aws ecr get-login-password --profile "$AWS_PROFILE" --region "$AWS_REGION" | docker login --username AWS --password-stdin "$ECR_URI"
+
+# Get the current Git commit hash
+GIT_COMMIT_HASH=$(git rev-parse --short HEAD)
+
+# push to registry
+# --provenance=true necessary to avoid the error https://stackoverflow.com/a/75149347/4820648
+docker buildx build \
+    --provenance=false \
+    --file lambda/Dockerfile \
+    --push \
+    --tag $ECR_REPO_URI:latest \
+    --tag $ECR_REPO_URI:$GIT_COMMIT_HASH \
+    --platform linux/amd64 \
+    --progress=plain \
+    lambda/.
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,11 @@ export interface ECRDeploymentProps {
   readonly dest: IImageName;
 
   /**
+   * The architecture of the docker images to copy.
+   */
+  readonly architecture?: string;
+
+  /**
    * The amount of memory (in MiB) to allocate to the AWS Lambda function which
    * replicates the files from the CDK bucket to the destination bucket.
    *
@@ -192,6 +197,7 @@ export class ECRDeployment extends Construct {
         SrcCreds: props.src.creds,
         DestImage: props.dest.uri,
         DestCreds: props.dest.creds,
+        Architecture: props.architecture,
       },
     });
   }

--- a/test/example.ecr-deployment.ts
+++ b/test/example.ecr-deployment.ts
@@ -32,11 +32,13 @@ class TestECRDeployment extends Stack {
     new ecrDeploy.ECRDeployment(this, 'DeployECRImage', {
       src: new ecrDeploy.DockerImageName(image.imageUri),
       dest: new ecrDeploy.DockerImageName(`${repo.repositoryUri}:latest`),
+      architecture: 'arm64',
     });
 
     new ecrDeploy.ECRDeployment(this, 'DeployDockerImage', {
       src: new ecrDeploy.DockerImageName('javacs3/javacs3:latest', 'dockerhub'),
       dest: new ecrDeploy.DockerImageName(`${repo.repositoryUri}:dockerhub`),
+      architecture: 'arm64',
     }).addToPrincipalPolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -879,9 +879,9 @@
     undici-types "~5.26.4"
 
 "@types/node@^18":
-  version "18.19.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.23.tgz#e02c759218bc9957423a3f7d585d511b17be2351"
-  integrity sha512-wtE3d0OUfNKtZYAqZb8HAWGxxXsImJcPUAgZNw+dWFxO6s5tIwIjyKnY76tsTatsNCLJPkVYwUpq15D38ng9Aw==
+  version "18.19.24"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.24.tgz#707d8a4907e55901466e60e8f7a62bc6197ace95"
+  integrity sha512-eghAz3gnbQbvnHqB+mgB2ZR3aH6RhdEmHGS48BnV75KceQPHqabkxKI0BbUSsqhqy2Ddhc2xD/VAR9ySZd57Lw==
   dependencies:
     undici-types "~5.26.4"
 
@@ -2064,9 +2064,9 @@ downlevel-dts@^0.11.0:
     typescript next
 
 electron-to-chromium@^1.4.668:
-  version "1.4.702"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.702.tgz#a05803c5a1a54f5eb727ce6a922a5923ef436261"
-  integrity sha512-LYLXyEUsZ3nNSwiOWjI88N1PJUAMU2QphQSgGLVkFnb3FxZxNui2Vzi2PaKPgPWbsWbZstZnh6BMf/VQJamjiQ==
+  version "1.4.704"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.704.tgz#218696fc0b1cb42298b9ae0612d9c4ffd6f8500e"
+  integrity sha512-OK01+86Qvby1V6cTiowVbhp25aX4DLZnwar+NocAOXdzKAByd+jq5156bmo4kHwevWMknznW18Y/Svfk2dU91A==
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -5445,9 +5445,9 @@ typescript@^4.9.5:
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 typescript@next:
-  version "5.5.0-dev.20240312"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.0-dev.20240312.tgz#6164816ce937d23391cf87865f25baf8e5b5057c"
-  integrity sha512-CEPqB9IvrkCgyoFCmsmQH4AXsXM+KX32FQvmVk8LYecfoNsow5+nW5ZwI8MiQUoGNZ78uTINFwyM1M6G/aNSrA==
+  version "5.5.0-dev.20240313"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.0-dev.20240313.tgz#85188512e63c98366d29b61752fd03fddd2b0c2f"
+  integrity sha512-6fXTCRKCmprlwHuUHH92w6Ll7na8PtjPCCUmUTHa2yl2lJZBtWNw4P/JmV0PuNMaByRWVX6ai008B7TYBKp3QA==
 
 typescript@~3.9.10:
   version "3.9.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2064,9 +2064,9 @@ downlevel-dts@^0.11.0:
     typescript next
 
 electron-to-chromium@^1.4.668:
-  version "1.4.704"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.704.tgz#218696fc0b1cb42298b9ae0612d9c4ffd6f8500e"
-  integrity sha512-OK01+86Qvby1V6cTiowVbhp25aX4DLZnwar+NocAOXdzKAByd+jq5156bmo4kHwevWMknznW18Y/Svfk2dU91A==
+  version "1.4.707"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.707.tgz#77904f87432b8b50b8b8b654ba3940d2bef48d63"
+  integrity sha512-qRq74Mo7ChePOU6GHdfAJ0NREXU8vQTlVlfWz3wNygFay6xrd/fY2J7oGHwrhFeU30OVctGLdTh/FcnokTWpng==
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -5445,9 +5445,9 @@ typescript@^4.9.5:
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 typescript@next:
-  version "5.5.0-dev.20240313"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.0-dev.20240313.tgz#85188512e63c98366d29b61752fd03fddd2b0c2f"
-  integrity sha512-6fXTCRKCmprlwHuUHH92w6Ll7na8PtjPCCUmUTHa2yl2lJZBtWNw4P/JmV0PuNMaByRWVX6ai008B7TYBKp3QA==
+  version "5.5.0-dev.20240314"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.0-dev.20240314.tgz#c75938db2cdc677891a880964c4ee8919b1065ca"
+  integrity sha512-8yyAVbLSgGrydN7CZWeP+GZ5zkEBh45r0LswVPgxNDjBuDx9VuKtp+ws+Ri122iwfy8vGr5b486IjeeVM49Crw==
 
 typescript@~3.9.10:
   version "3.9.10"


### PR DESCRIPTION
Fixes #568 


Currently we can only copy images for the `amd64` architecture. [copy supports `ArchitectureChoice`](https://github.com/containers/image/blob/v5.21.0/types/types.go#L579) which is leveraged in this PR. If no `Architecture` is provided the current behavior applies (uses the platform architecture, which is x86). 