### PR TITLE
chore: "Publish Lambda" step should run after "GitHub Release" step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,9 @@ jobs:
         run: npx -p publib@latest publib-golang
   release_prebuilt_lambda:
     name: Publish Lambda to GitHub Releases
-    needs: release
+    needs:
+      - release
+      - release_github
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -52,7 +52,7 @@ project.release?.addJobs({
   release_prebuilt_lambda: {
     runsOn: ['ubuntu-latest'],
     name: 'Publish Lambda to GitHub Releases',
-    needs: ['release'],
+    needs: ['release', 'release_github'],
     permissions: {
       contents: github.workflows.JobPermission.WRITE,
     },


### PR DESCRIPTION
The "Publish Lambda" step depends on a GitHub Release existing, but it doesn't have a dependency on the step that creates said GitHub Release.

Add that dependency.
