### PR TITLE
fix: use golang image from public.ecr.aws

### DIFF
--- a/lambda/Dockerfile
+++ b/lambda/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-ARG buildImage=golang:1
+ARG buildImage=public.ecr.aws/docker/library/golang:1
 FROM ${buildImage} as build
 
 USER root

--- a/lambda/Dockerfile
+++ b/lambda/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 ARG buildImage=public.ecr.aws/docker/library/golang:1
-FROM ${buildImage} as build
+FROM ${buildImage} AS build
 
 USER root
 

--- a/test/lambda/Dockerfile
+++ b/test/lambda/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-ARG buildImage=golang:1
-FROM ${buildImage} as build
+ARG buildImage=public.ecr.aws/docker/library/golang:1
+FROM ${buildImage} AS build
 
 USER root
 


### PR DESCRIPTION
Use `public.ecr.aws/docker/library/golang:1` to avoid docker hub pull limit
