### PR TITLE
feat: support JSON Credentials as repo secret

### DIFF
--- a/lambda/main.go
+++ b/lambda/main.go
@@ -163,6 +163,9 @@ func parseCreds(creds string) (string, error) {
 		return secret, err
 	} else if credsType == SECRET_TEXT {
 		return creds, nil
+	} else if credsType == SECRET_JSON {
+		secret, err := GetJSONSecret(creds)
+		return secret, err
 	}
-	return "", fmt.Errorf("unkown creds type")
+	return "", fmt.Errorf("unknown creds type")
 }

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -159,12 +159,22 @@ func parseCreds(creds string) (string, error) {
 	if creds == "" {
 		return "", nil
 	} else if (credsType == SECRET_ARN) || (credsType == SECRET_NAME) {
-		secret, err := GetSecret(creds)
-		return secret, err
+		secret, isJSON, err := GetSecret(creds)
+		if err != nil {
+			return "", err
+		}
+		if isJSON {
+			parsedSecret, err := ParseJSONSecret(secret)
+			if err != nil {
+				return "", err
+			}
+			return parsedSecret, nil
+		}
+		return secret, nil
 	} else if credsType == SECRET_TEXT {
 		return creds, nil
 	} else if credsType == SECRET_JSON {
-		secret, err := GetJSONSecret(creds)
+		secret, err := ParseJSONSecret(creds)
 		return secret, err
 	}
 	return "", fmt.Errorf("unknown creds type")

--- a/lambda/main_test.go
+++ b/lambda/main_test.go
@@ -53,3 +53,53 @@ func TestMain(t *testing.T) {
 	})
 	assert.NoError(t, err)
 }
+func TestParseCreds(t *testing.T) {
+	tests := []struct {
+		name    string
+		creds   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Empty creds",
+			creds:   "",
+			want:    "",
+			wantErr: false,
+		},
+		// {
+		// 	name:    "Secret ARN",
+		// 	creds:   "arn:aws:secretsmanager:us-west-2:00000:secret:fake-secret",
+		// 	want:    "{\"username\":\"privateRegistryUsername\",\"password\":\"privateRegistryPassword\"}",
+		// 	wantErr: false,
+		// },
+		{
+			name:    "Secret JSON",
+			creds:   "{ \"username\" : \"privateRegistryUsername\", \"password\" : \"privateRegistryPassword\" }",
+			want:    "privateRegistryUsername:privateRegistryPassword",
+			wantErr: false,
+		},
+		{
+			name:    "Secret Text",
+			creds:   "username:password",
+			want:    "username:password",
+			wantErr: false,
+		},
+		{
+			name:    "Unknown creds type",
+			creds:   "unknown-creds",
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCreds(tt.creds)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseCreds() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/lambda/utils_test.go
+++ b/lambda/utils_test.go
@@ -30,4 +30,5 @@ func TestGetCredsType(t *testing.T) {
 	assert.Equal(t, SECRET_NAME, GetCredsType("fake-secret"))
 	assert.Equal(t, SECRET_TEXT, GetCredsType("username:password"))
 	assert.Equal(t, SECRET_NAME, GetCredsType(""))
+	assert.Equal(t, SECRET_JSON, GetCredsType("{ \"username\" : \"privateRegistryUsername\", \"password\" : \"privateRegistryPassword\" }"))
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,7 @@ export interface IImageName {
 
   /**
    * The credentials of the docker image. Format `user:password` or `AWS Secrets Manager secret arn` or `AWS Secrets Manager secret name`
+   * Supports JSON format returned from AWS Secrets in the format `{"username":"<username>", "password":"<password>"}`
    */
   creds?: string;
 }


### PR DESCRIPTION
Fixes #900

Added new functionality to GetCredsType in utils.go to parse JSON Username/Password in this format:
`{ "username": "someusername", "password": "somepassword" }`

Added new function, GetJSONSecret to parse and return the JSON Username/Password above to utils.go.

Updated parseCreds in main.go to look for SECRET_JSON and call the GetJSONSecret and return the creds.

Corrected spelling of unknown in error return of parseCreds in main.go.

Tests pass in utils_test.go.