### PR TITLE
feat: Add support to explicitly specify a CPU architecture for the to-be-copied image instead of relying on auto-detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ jspm_packages/
 .yarn-integrity
 .cache
 cdk.out/
+lambda/out/bootstrap
 /test-reports/
 junit.xml
 /coverage/

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -36,6 +36,7 @@ const project = new CdklabsConstructLibrary({
   repositoryUrl: 'https://github.com/cdklabs/cdk-ecr-deployment', /* The repository is the location where the actual code for your package lives. */
   gitignore: [
     'cdk.out/',
+    'lambda/out/bootstrap',
   ], /* Additional entries to .gitignore. */
   npmignore: [
     '/cdk.out',

--- a/API.md
+++ b/API.md
@@ -148,6 +148,7 @@ const eCRDeploymentProps: ECRDeploymentProps = { ... }
 | <code><a href="#cdk-ecr-deployment.ECRDeploymentProps.property.src">src</a></code> | <code><a href="#cdk-ecr-deployment.IImageName">IImageName</a></code> | The source of the docker image. |
 | <code><a href="#cdk-ecr-deployment.ECRDeploymentProps.property.buildImage">buildImage</a></code> | <code>string</code> | Image to use to build Golang lambda for custom resource, if download fails or is not wanted. |
 | <code><a href="#cdk-ecr-deployment.ECRDeploymentProps.property.environment">environment</a></code> | <code>{[ key: string ]: string}</code> | The environment variable to set. |
+| <code><a href="#cdk-ecr-deployment.ECRDeploymentProps.property.imageArch">imageArch</a></code> | <code>string</code> | The image architecture to be copied. |
 | <code><a href="#cdk-ecr-deployment.ECRDeploymentProps.property.lambdaHandler">lambdaHandler</a></code> | <code>string</code> | The name of the lambda handler. |
 | <code><a href="#cdk-ecr-deployment.ECRDeploymentProps.property.lambdaRuntime">lambdaRuntime</a></code> | <code>aws-cdk-lib.aws_lambda.Runtime</code> | The lambda function runtime environment. |
 | <code><a href="#cdk-ecr-deployment.ECRDeploymentProps.property.memoryLimit">memoryLimit</a></code> | <code>number</code> | The amount of memory (in MiB) to allocate to the AWS Lambda function which replicates the files from the CDK bucket to the destination bucket. |
@@ -208,6 +209,19 @@ public readonly environment: {[ key: string ]: string};
 - *Type:* {[ key: string ]: string}
 
 The environment variable to set.
+
+---
+
+##### `imageArch`<sup>Optional</sup> <a name="imageArch" id="cdk-ecr-deployment.ECRDeploymentProps.property.imageArch"></a>
+
+```typescript
+public readonly imageArch: string;
+```
+
+- *Type:* string
+- *Default:* the underlying lambda auto-detects the relevant architecture (e.g., amd64, arm64) https://github.com/containers/image/blob/main/internal/pkg/platform/platform_matcher.go#L161
+
+The image architecture to be copied.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -148,7 +148,7 @@ const eCRDeploymentProps: ECRDeploymentProps = { ... }
 | <code><a href="#cdk-ecr-deployment.ECRDeploymentProps.property.src">src</a></code> | <code><a href="#cdk-ecr-deployment.IImageName">IImageName</a></code> | The source of the docker image. |
 | <code><a href="#cdk-ecr-deployment.ECRDeploymentProps.property.buildImage">buildImage</a></code> | <code>string</code> | Image to use to build Golang lambda for custom resource, if download fails or is not wanted. |
 | <code><a href="#cdk-ecr-deployment.ECRDeploymentProps.property.environment">environment</a></code> | <code>{[ key: string ]: string}</code> | The environment variable to set. |
-| <code><a href="#cdk-ecr-deployment.ECRDeploymentProps.property.imageArch">imageArch</a></code> | <code>string</code> | The image architecture to be copied. |
+| <code><a href="#cdk-ecr-deployment.ECRDeploymentProps.property.imageArch">imageArch</a></code> | <code>string[]</code> | The image architecture to be copied. |
 | <code><a href="#cdk-ecr-deployment.ECRDeploymentProps.property.lambdaHandler">lambdaHandler</a></code> | <code>string</code> | The name of the lambda handler. |
 | <code><a href="#cdk-ecr-deployment.ECRDeploymentProps.property.lambdaRuntime">lambdaRuntime</a></code> | <code>aws-cdk-lib.aws_lambda.Runtime</code> | The lambda function runtime environment. |
 | <code><a href="#cdk-ecr-deployment.ECRDeploymentProps.property.memoryLimit">memoryLimit</a></code> | <code>number</code> | The amount of memory (in MiB) to allocate to the AWS Lambda function which replicates the files from the CDK bucket to the destination bucket. |
@@ -215,13 +215,19 @@ The environment variable to set.
 ##### `imageArch`<sup>Optional</sup> <a name="imageArch" id="cdk-ecr-deployment.ECRDeploymentProps.property.imageArch"></a>
 
 ```typescript
-public readonly imageArch: string;
+public readonly imageArch: string[];
 ```
 
-- *Type:* string
-- *Default:* the underlying lambda auto-detects the relevant architecture (e.g., amd64, arm64) https://github.com/containers/image/blob/main/internal/pkg/platform/platform_matcher.go#L161
+- *Type:* string[]
+- *Default:* ['amd64']
 
 The image architecture to be copied.
+
+The 'amd64' architecture will be copied by default. Specify the
+architecture or architectures to copy here.
+
+It is currently not possible to copy more than one architecture
+at a time: the array you specify must contain exactly one string.
 
 ---
 

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -53,6 +53,10 @@ func handler(ctx context.Context, event cfn.Event) (physicalResourceID string, d
 		if err != nil {
 			return physicalResourceID, data, err
 		}
+		imageArch, err := getStrPropsDefault(event.ResourceProperties, IMAGE_ARCH, "")
+		if err != nil {
+			return physicalResourceID, data, err
+		}
 		srcCreds, err := getStrPropsDefault(event.ResourceProperties, SRC_CREDS, "")
 		if err != nil {
 			return physicalResourceID, data, err
@@ -71,7 +75,7 @@ func handler(ctx context.Context, event cfn.Event) (physicalResourceID string, d
 			return physicalResourceID, data, err
 		}
 
-		log.Printf("SrcImage: %v DestImage: %v", srcImage, destImage)
+		log.Printf("SrcImage: %v DestImage: %v ImageArch: %v", srcImage, destImage, imageArch)
 
 		srcRef, err := alltransports.ParseImageName(srcImage)
 		if err != nil {
@@ -82,13 +86,13 @@ func handler(ctx context.Context, event cfn.Event) (physicalResourceID string, d
 			return physicalResourceID, data, err
 		}
 
-		srcOpts := NewImageOpts(srcImage)
+		srcOpts := NewImageOpts(srcImage, imageArch)
 		srcOpts.SetCreds(srcCreds)
 		srcCtx, err := srcOpts.NewSystemContext()
 		if err != nil {
 			return physicalResourceID, data, err
 		}
-		destOpts := NewImageOpts(destImage)
+		destOpts := NewImageOpts(destImage, imageArch)
 		destOpts.SetCreds(destCreds)
 		destCtx, err := destOpts.NewSystemContext()
 		if err != nil {

--- a/lambda/main_test.go
+++ b/lambda/main_test.go
@@ -33,10 +33,10 @@ func TestMain(t *testing.T) {
 	destRef, err := alltransports.ParseImageName(destImage)
 	assert.NoError(t, err)
 
-	srcOpts := NewImageOpts(srcImage)
+	srcOpts := NewImageOpts(srcImage, "")
 	srcCtx, err := srcOpts.NewSystemContext()
 	assert.NoError(t, err)
-	destOpts := NewImageOpts(destImage)
+	destOpts := NewImageOpts(destImage, "")
 	destCtx, err := destOpts.NewSystemContext()
 	assert.NoError(t, err)
 
@@ -51,5 +51,14 @@ func TestMain(t *testing.T) {
 		DestinationCtx: destCtx,
 		SourceCtx:      srcCtx,
 	})
+	assert.NoError(t, err)
+}
+
+func TestNewImageOpts(t *testing.T) {
+	srcOpts := NewImageOpts("s3://cdk-ecr-deployment/nginx.tar:nginx:latest", "arm64")
+	_, err := srcOpts.NewSystemContext()
+	assert.NoError(t, err)
+	destOpts := NewImageOpts("dir:/tmp/nginx.dir", "arm64")
+	_, err = destOpts.NewSystemContext()
 	assert.NoError(t, err)
 }

--- a/lambda/utils.go
+++ b/lambda/utils.go
@@ -23,6 +23,7 @@ import (
 const (
 	SRC_IMAGE  string = "SrcImage"
 	DEST_IMAGE string = "DestImage"
+	IMAGE_ARCH string = "ImageArch"
 	SRC_CREDS  string = "SrcCreds"
 	DEST_CREDS string = "DestCreds"
 )
@@ -86,14 +87,15 @@ type ImageOpts struct {
 	requireECRLogin bool
 	region          string
 	creds           string
+	arch            string
 }
 
-func NewImageOpts(uri string) *ImageOpts {
+func NewImageOpts(uri string, arch string) *ImageOpts {
 	requireECRLogin := strings.Contains(uri, "dkr.ecr")
 	if requireECRLogin {
-		return &ImageOpts{uri, requireECRLogin, GetECRRegion(uri), ""}
+		return &ImageOpts{uri, requireECRLogin, GetECRRegion(uri), "", arch}
 	} else {
-		return &ImageOpts{uri, requireECRLogin, "", ""}
+		return &ImageOpts{uri, requireECRLogin, "", "", arch}
 	}
 }
 
@@ -109,6 +111,7 @@ func (s *ImageOpts) NewSystemContext() (*types.SystemContext, error) {
 	ctx := &types.SystemContext{
 		DockerRegistryUserAgent: "ecr-deployment",
 		DockerAuthConfig:        &types.DockerAuthConfig{},
+		ArchitectureChoice:      s.arch,
 	}
 
 	if s.creds != "" {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,14 @@ export interface ECRDeploymentProps {
   readonly dest: IImageName;
 
   /**
+   * The image architecture to be copied.
+   *
+   * @default - the underlying lambda auto-detects the relevant architecture (e.g., amd64, arm64)
+   * https://github.com/containers/image/blob/main/internal/pkg/platform/platform_matcher.go#L161
+   */
+  readonly imageArch?: string;
+
+  /**
    * The amount of memory (in MiB) to allocate to the AWS Lambda function which
    * replicates the files from the CDK bucket to the destination bucket.
    *
@@ -207,6 +215,7 @@ export class ECRDeployment extends Construct {
         SrcCreds: props.src.creds,
         DestImage: props.dest.uri,
         DestCreds: props.dest.creds,
+        ImageArch: props.imageArch ?? '',
       },
     });
   }

--- a/test/ecr-deployment.test.ts
+++ b/test/ecr-deployment.test.ts
@@ -1,0 +1,61 @@
+import { Stack, App, aws_ecr as ecr, assertions } from 'aws-cdk-lib';
+import { DockerImageName, ECRDeployment } from '../src';
+
+// Yes, it's a lie. It's also the truth.
+const CUSTOM_RESOURCE_TYPE = 'Custom::CDKBucketDeployment';
+
+let app: App;
+let stack: Stack;
+
+const src = new DockerImageName('javacs3/javacs3:latest', 'dockerhub');
+let dest: DockerImageName;
+beforeEach(() => {
+  app = new App();
+  stack = new Stack(app, 'Stack');
+
+  const repo = new ecr.Repository(stack, 'Repo', {
+    repositoryName: 'repo',
+  });
+  dest = new DockerImageName(`${repo.repositoryUri}:copied`);
+
+  // Otherwise we do a Docker build :x
+  process.env.FORCE_PREBUILT_LAMBDA = 'true';
+});
+
+test('ImageArch is missing from custom resource if argument not specified', () => {
+  // WHEN
+  new ECRDeployment(stack, 'ECR', {
+    src,
+    dest,
+  });
+
+  // THEN
+  const template = assertions.Template.fromStack(stack);
+  template.hasResourceProperties(CUSTOM_RESOURCE_TYPE, {
+    ImageArch: assertions.Match.absent(),
+  });
+});
+
+test('ImageArch is in custom resource properties if specified', () => {
+  // WHEN
+  new ECRDeployment(stack, 'ECR', {
+    src,
+    dest,
+    imageArch: ['banana'],
+  });
+
+  // THEN
+  const template = assertions.Template.fromStack(stack);
+  template.hasResourceProperties(CUSTOM_RESOURCE_TYPE, {
+    ImageArch: 'banana',
+  });
+});
+
+test('Cannot specify more or fewer than 1 elements in imageArch', () => {
+  // WHEN
+  expect(() => new ECRDeployment(stack, 'ECR', {
+    src,
+    dest,
+    imageArch: ['banana', 'pear'],
+  })).toThrow(/imageArch must contain exactly 1 element/);
+});

--- a/test/example.ecr-deployment.ts
+++ b/test/example.ecr-deployment.ts
@@ -37,7 +37,7 @@ class TestECRDeployment extends Stack {
     new ecrDeploy.ECRDeployment(this, 'DeployECRImage', {
       src: new ecrDeploy.DockerImageName(image.imageUri),
       dest: new ecrDeploy.DockerImageName(`${repo.repositoryUri}:latest`),
-      imageArch: 'arm64',
+      imageArch: ['arm64'],
     });
 
     new ecrDeploy.ECRDeployment(this, 'DeployDockerImage', {
@@ -54,7 +54,7 @@ class TestECRDeployment extends Stack {
     new ecrDeploy.ECRDeployment(this, 'DeployDockerImage', {
       src: new ecrDeploy.DockerImageName('javacs3/javacs3:latest', 'dockerhub'),
       dest: new ecrDeploy.DockerImageName(`${repo.repositoryUri}:dockerhub`),
-      imageArch: 'amd64',
+      imageArch: ['amd64'],
     }).addToPrincipalPolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: [

--- a/test/example.ecr-deployment.ts
+++ b/test/example.ecr-deployment.ts
@@ -34,9 +34,27 @@ class TestECRDeployment extends Stack {
       dest: new ecrDeploy.DockerImageName(`${repo.repositoryUri}:latest`),
     });
 
+    new ecrDeploy.ECRDeployment(this, 'DeployECRImage', {
+      src: new ecrDeploy.DockerImageName(image.imageUri),
+      dest: new ecrDeploy.DockerImageName(`${repo.repositoryUri}:latest`),
+      imageArch: 'arm64',
+    });
+
     new ecrDeploy.ECRDeployment(this, 'DeployDockerImage', {
       src: new ecrDeploy.DockerImageName('javacs3/javacs3:latest', 'dockerhub'),
       dest: new ecrDeploy.DockerImageName(`${repo.repositoryUri}:dockerhub`),
+    }).addToPrincipalPolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'secretsmanager:GetSecretValue',
+      ],
+      resources: ['*'],
+    }));
+
+    new ecrDeploy.ECRDeployment(this, 'DeployDockerImage', {
+      src: new ecrDeploy.DockerImageName('javacs3/javacs3:latest', 'dockerhub'),
+      dest: new ecrDeploy.DockerImageName(`${repo.repositoryUri}:dockerhub`),
+      imageArch: 'amd64',
     }).addToPrincipalPolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: [


### PR DESCRIPTION
### What's the problem?

It's observed that when copying a multi-arch source image from location A to B in ECR, we always end up with `amd64` in the destination image at location B.  The hypothesis is that the underlying lambda function used to auto-detect the architecture is backed up by Dockerfile with [a hard-coded runtime.GOARCH](https://github.com/cdklabs/cdk-ecr-deployment/blob/dcd74cdfc394d6a43a5517cb5cce1843e1fe3111/lambda/Dockerfile#L11).

### Proposed Solution
Instead of solely relying on an auto-detection mechanism, this PR is meant to add a feature to allow users to explicitly specify a CPU architecture for the to-be-copied image, by triggering the underlying logic [here](https://github.com/containers/image/blob/5263462aa97ae23d3a620b4dcdbbc557665a42c8/internal/pkg/platform/platform_matcher.go#L164).  This will unblock the usage of Graviton instances for [Amazon SageMaker](https://aws.amazon.com/sagemaker/) and other computing platforms.

As a side note, I've run `npm run release` on my dev box to refresh `API.md`
