### PR TITLE
fix: attempt to fix bootstrap download issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 cdk.out/
-lambda/out/bootstrap
 /test-reports/
 junit.xml
 /coverage/

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -34,7 +34,6 @@ const project = new CdklabsConstructLibrary({
   repositoryUrl: 'https://github.com/cdklabs/cdk-ecr-deployment', /* The repository is the location where the actual code for your package lives. */
   gitignore: [
     'cdk.out/',
-    'lambda/out/bootstrap',
   ], /* Additional entries to .gitignore. */
   npmignore: [
     '/cdk.out',


### PR DESCRIPTION
Fixes #1017 

I honestly don't know if this fixes the problem, but couldn't hurt to try if it's one of the more obvious things that could have caused a problem between the 3.0.x and 3.1.x version based on the following PR:

https://github.com/cdklabs/cdk-ecr-deployment/issues/961