### PR TITLE
fix: custom resource handler does not have a description

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ export class ECRDeployment extends Construct {
       runtime: new lambda.Runtime('provided.al2023', RuntimeFamily.OTHER), // not using Runtime.PROVIDED_AL2023 to support older CDK versions (< 2.105.0)
       handler: 'bootstrap',
       lambdaPurpose: 'Custom::CDKECRDeployment',
-      description: 'Custom resource handler for copying Docker images between registries and S3 archives.',
+      description: 'Custom resource handler for copying Docker images between docker registries.',
       timeout: Duration.minutes(15),
       role: props.role,
       memorySize: memoryLimit,

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,7 @@ export class ECRDeployment extends Construct {
       runtime: new lambda.Runtime('provided.al2023', RuntimeFamily.OTHER), // not using Runtime.PROVIDED_AL2023 to support older CDK versions (< 2.105.0)
       handler: 'bootstrap',
       lambdaPurpose: 'Custom::CDKECRDeployment',
+      description: 'Custom resource handler for copying Docker images between registries and S3 archives.',
       timeout: Duration.minutes(15),
       role: props.role,
       memorySize: memoryLimit,


### PR DESCRIPTION
Adds a default description to the singleton Lambda function to improve resource identification in the AWS Console. The description clarifies that this Lambda is used as a custom resource handler for copying Docker images between registries and S3 archives.

Description added: "Custom resource handler for copying Docker images between docker registries."

Resolves #1104
