### PR TITLE
fix: parse json secret when there is no error returned.

### DIFF
--- a/lambda-src/main.go
+++ b/lambda-src/main.go
@@ -165,7 +165,7 @@ func parseCreds(creds string) (string, error) {
 		return "", nil
 	} else if (credsType == SECRET_ARN) || (credsType == SECRET_NAME) {
 		secret, err := GetSecret(creds)
-		if err != nil && len(secret) > 0 && json.Valid([]byte(secret)) {
+		if err == nil && len(secret) > 0 && json.Valid([]byte(secret)) {
 			secret, err = ParseJsonSecret(secret)
 		}
 		return secret, err


### PR DESCRIPTION
Did not open an issue for this as contributing guidelines recommended issues for larger discussions, but I would be happy to open an issue if desired.

This work is building on the following PR: https://github.com/cdklabs/cdk-ecr-deployment/pull/1090
This work is from original issue: https://github.com/cdklabs/cdk-ecr-deployment/issues/900

This fixes the case that the secret string content is valid and there is no error returned. The error check should have been for empty rather than not empty to attempt to parse the string as JSON.

**Current Code**
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/cc7c2390-41b7-4eff-b8bd-39c7a1c0b6a9" />


**With these Changes**
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/f0efb508-9af9-4213-bd3a-f87ed2a66938" />

**Testing that Regular Plaintext Secret Still Works**
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/45193c84-54de-4cb2-8428-4942ecfc7fd3" />

