### PR TITLE
fix(lambda): S3 archive copy fails with 416 when tar size is a multiple of 8 MiB

### DIFF
--- a/lambda-src/internal/tarfile/s3file.go
+++ b/lambda-src/internal/tarfile/s3file.go
@@ -327,7 +327,10 @@ func (c *BlockCache) Read(begin, end int64, cacheMissFn CacheMissFn) (buf []byte
 		return nil, fmt.Errorf("LRUBlockCache: byte end must greater than byte begin")
 	}
 	bidBegin := begin / iolimits.BlockSize
-	bidEnd := end / iolimits.BlockSize
+	// Use (end - 1) so a read that ends exactly on a block boundary does not
+	// request the next block, which would start at/after EOF and make S3 return
+	// 416 InvalidRange. begin < end is guaranteed above, so end-1 >= begin >= 0.
+	bidEnd := (end - 1) / iolimits.BlockSize
 	buf = make([]byte, 0)
 
 	for bid := bidBegin; bid <= bidEnd; bid++ {

--- a/lambda-src/internal/tarfile/s3file_test.go
+++ b/lambda-src/internal/tarfile/s3file_test.go
@@ -92,6 +92,36 @@ func TestBlockCache(t *testing.T) {
 	assert.Equal(t, append(mkblk(magic(0)), magic(1)...), buf)
 }
 
+// Reproduces https://github.com/cdklabs/cdk-ecr-deployment/issues/1270:
+// when an object's size is an exact multiple of BlockSize, reading up to EOF
+// must not request the block that starts at EOF (S3 answers 416 InvalidRange).
+// Also guards the (end-1) math against off-by-one edges (e.g. end == 1).
+func TestBlockCacheReadAtAlignedEOF(t *testing.T) {
+	cases := []struct {
+		name        string
+		size, begin, end int64
+	}{
+		{"single 8MiB block to EOF", iolimits.BlockSize, 0, iolimits.BlockSize},
+		{"two 8MiB blocks to EOF", 2 * iolimits.BlockSize, 0, 2 * iolimits.BlockSize},
+		{"single byte read", iolimits.BlockSize, 0, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mirrors S3File.onCacheMiss: S3 returns 416 when the range start is at/past EOF.
+			cacheMissFn := func(block *Block) error {
+				if block.Id*iolimits.BlockSize >= tc.size {
+					return fmt.Errorf("StatusCode: 416, api error InvalidRange: The requested range is not satisfiable")
+				}
+				return nil
+			}
+			cache := NewBlockCache(iolimits.CacheBlockCount)
+			buf, err := cache.Read(tc.begin, tc.end, cacheMissFn)
+			assert.NoError(t, err)
+			assert.Equal(t, int(tc.end-tc.begin), len(buf))
+		})
+	}
+}
+
 func TestLRUBlockPool(t *testing.T) {
 	n := 0
 	pool := NewLRUBlockPool(1)


### PR DESCRIPTION
Copying an `S3ArchiveName` source whose S3 object size is an exact multiple of the 8 MiB block size used by the lambda's read cache failed immediately with `416 InvalidRange: The requested range is not satisfiable`, surfaced through CloudFormation as `determining manifest MIME type for s3://...: error when get block from pool`. Because the failure depends on the object landing exactly on an 8 MiB boundary, it was latent for most images and only struck the unlucky few, which made it hard to diagnose.

The cause is an off-by-one in the block cache. While walking the tar, `containers/image` issues a read that ends exactly at EOF. The cache computed the inclusive end block as `end / BlockSize`, so an `end` sitting exactly on a block boundary pointed at the block that *starts* at EOF. Fetching that block asked S3 for a range beginning at or past the object size, which S3 rejects with 416. Using `(end - 1) / BlockSize` keeps the end block within the data that actually needs to be read; the existing `begin < end` guard guarantees `end - 1` is never negative, so the boundary and single-byte cases stay correct.

I reproduced the original error end to end with a valid image padded to exactly 16 MiB (an earlier attempt with a NUL-padded tar did not trigger it, because the tar reader stops at the archive's end-of-archive marker and never reaches the aligned EOF — the real images that hit this have genuine layer data filling the file). The added regression test drives the block cache directly and covers the exact-8 MiB single block, two blocks, and the single-byte edge.

Fixes #1270
