### PR TITLE
fix: retry on S3 503 and transient network errors during image copy

### DIFF
--- a/lambda-src/utils.go
+++ b/lambda-src/utils.go
@@ -359,6 +359,10 @@ func IsECRRateLimitError(err error) bool {
 	return strings.Contains(s, "toomanyrequests") ||
 		strings.Contains(s, "ratelimitexceeded") ||
 		strings.Contains(s, "rate exceeded") ||
+		strings.Contains(s, "slow down") ||
+		strings.Contains(s, "503 service unavailable") ||
+		strings.Contains(s, "500 internal server error") ||
+		strings.Contains(s, "connection reset by peer") ||
 		(strings.Contains(s, "rate") && strings.Contains(s, "exceed"))
 }
 

--- a/lambda-src/utils_test.go
+++ b/lambda-src/utils_test.go
@@ -268,6 +268,31 @@ func TestIsECRRateLimitError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "S3 503 Slow Down during blob read",
+			err:      errors.New("reading blob sha256:abc123: fetching blob: received unexpected HTTP status: 503 Slow Down (RequestId: req-001)"),
+			expected: true,
+		},
+		{
+			name:     "S3 503 Service Unavailable during blob read",
+			err:      errors.New("reading blob sha256:def456: fetching blob: received unexpected HTTP status: 503 Service Unavailable (RequestId: req-002)"),
+			expected: true,
+		},
+		{
+			name:     "bare slow down string",
+			err:      errors.New("Slow Down"),
+			expected: true,
+		},
+		{
+			name:     "500 Internal Server Error during blob read",
+			err:      errors.New("reading blob sha256:ghi789: fetching blob: received unexpected HTTP status: 500 Internal Server Error (RequestId: req-003)"),
+			expected: true,
+		},
+		{
+			name:     "connection reset by peer during image init",
+			err:      errors.New("initializing source docker://123456789012.dkr.ecr.us-west-2.amazonaws.com/repo:tag: read tcp 10.0.0.1:48000->10.0.0.2:443: read: connection reset by peer"),
+			expected: true,
+		},
+		{
 			name:     "unrelated error returns false",
 			err:      errors.New("connection timeout"),
 			expected: false,


### PR DESCRIPTION
IsECRRateLimitError() now matches transient errors that occur during image copy operations:
- S3 throttling: 503 Slow Down, 503 Service Unavailable (blob layer downloads use S3 presigned URLs which return 503 for throttling)
- Transient network: 500 Internal Server Error, connection reset by peer

These are added to the existing string-match fallback so the retry loop fires for all observed transient error classes.

Fixes #1328