### PR TITLE
fix: broaden retry to cover S3 throttling and transient network errors

### DIFF
--- a/lambda-src/main.go
+++ b/lambda-src/main.go
@@ -226,9 +226,9 @@ func copyImage(srcImage string, destImage string, srcCreds string, destCreds str
 		if err == nil {
 			return nil
 		}
-		if IsECRRateLimitError(err) && i < (attempts-1) {
+		if IsRetryableError(err) && i < (attempts-1) {
 			wait := BackoffWithJitter(i+1, baseDelay, maxDelay)
-			log.Printf("Exceeded rate limit for ECR PutImages on attempt (%v/%v). Retrying in %v...", (i + 1), attempts, wait)
+			log.Printf("Transient error on attempt (%v/%v). Retrying in %v... Error: %s", (i + 1), attempts, wait, err.Error())
 			time.Sleep(wait)
 			continue
 		}

--- a/lambda-src/utils.go
+++ b/lambda-src/utils.go
@@ -340,12 +340,18 @@ func (rc *RetryConfigs) ValidateFields() error {
 	return nil
 }
 
-// Helper function to check if an error is a "rate limit exceeded" from ECR API calls
-func IsECRRateLimitError(err error) bool {
+// IsRetryableError checks if an error is transient and should be retried.
+// This covers ECR API rate limits, S3 throttling during blob transfers,
+// and transient network errors.
+func IsRetryableError(err error) bool {
 	if err == nil {
 		return false
 	}
+	return IsECRRateLimitError(err) || IsS3ThrottlingError(err) || IsTransientNetworkError(err)
+}
 
+// IsECRRateLimitError checks for ECR API rate-limit errors (push-side throttling).
+func IsECRRateLimitError(err error) bool {
 	// Attempt to cast it as a smithy APIError
 	var apiErr smithy.APIError
 	if errors.As(err, &apiErr) {
@@ -354,12 +360,26 @@ func IsECRRateLimitError(err error) bool {
 		}
 	}
 
-	// Fallback to string matching
 	s := strings.ToLower(err.Error())
 	return strings.Contains(s, "toomanyrequests") ||
 		strings.Contains(s, "ratelimitexceeded") ||
 		strings.Contains(s, "rate exceeded") ||
 		(strings.Contains(s, "rate") && strings.Contains(s, "exceed"))
+}
+
+// IsS3ThrottlingError checks for S3 throttling errors during blob layer downloads.
+// ECR stores layers in S3 and serves them via presigned URLs; S3 uses HTTP 503 for throttling.
+func IsS3ThrottlingError(err error) bool {
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "slow down") ||
+		strings.Contains(s, "503 service unavailable")
+}
+
+// IsTransientNetworkError checks for transient server and network errors.
+func IsTransientNetworkError(err error) bool {
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "500 internal server error") ||
+		strings.Contains(s, "connection reset by peer")
 }
 
 // A simple backoff with jitter formula that's used for retries.

--- a/lambda-src/utils_test.go
+++ b/lambda-src/utils_test.go
@@ -221,7 +221,7 @@ func (e *mockAPIError) ErrorFault() int {
 	return e.fault
 }
 
-func TestIsECRRateLimitError(t *testing.T) {
+func TestIsRetryableError(t *testing.T) {
 	testCases := []struct {
 		name     string
 		err      error
@@ -232,6 +232,7 @@ func TestIsECRRateLimitError(t *testing.T) {
 			err:      nil,
 			expected: false,
 		},
+		// ECR API rate limits
 		{
 			name:     "smithy APIError with ECR rate exceed message",
 			err:      &mockAPIError{code: "ThrottlingException", message: "toomanyrequests: Rate exceeded"},
@@ -267,16 +268,44 @@ func TestIsECRRateLimitError(t *testing.T) {
 			err:      fmt.Errorf("wrapped: %w", &mockAPIError{code: "ThrottlingException", message: "toomanyrequests: Rate exceeded"}),
 			expected: true,
 		},
+		// S3 throttling (read-side)
+		{
+			name:     "S3 503 Slow Down during blob read",
+			err:      errors.New("reading blob sha256:abc123: fetching blob: received unexpected HTTP status: 503 Slow Down (RequestId: req-001)"),
+			expected: true,
+		},
+		{
+			name:     "S3 503 Service Unavailable during blob read",
+			err:      errors.New("reading blob sha256:def456: fetching blob: received unexpected HTTP status: 503 Service Unavailable (RequestId: req-002)"),
+			expected: true,
+		},
+		// Transient network errors
+		{
+			name:     "500 Internal Server Error during blob read",
+			err:      errors.New("reading blob sha256:ghi789: fetching blob: received unexpected HTTP status: 500 Internal Server Error (RequestId: req-003)"),
+			expected: true,
+		},
+		{
+			name:     "connection reset by peer during image init",
+			err:      errors.New("initializing source docker://123456789012.dkr.ecr.us-west-2.amazonaws.com/repo:tag: read tcp 10.0.0.1:48000->10.0.0.2:443: read: connection reset by peer"),
+			expected: true,
+		},
+		// Negative cases
 		{
 			name:     "unrelated error returns false",
 			err:      errors.New("connection timeout"),
+			expected: false,
+		},
+		{
+			name:     "permanent error returns false",
+			err:      errors.New("invalid image reference format"),
 			expected: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := IsECRRateLimitError(tc.err)
+			result := IsRetryableError(tc.err)
 			assert.Equal(t, tc.expected, result)
 		})
 	}


### PR DESCRIPTION
Introduce IsRetryableError() as a composition of named predicates:
- IsECRRateLimitError: existing ECR API push-side throttling
- IsS3ThrottlingError: S3 503 Slow Down / Service Unavailable during blob reads (ECR stores layers in S3 via presigned URLs)
- IsTransientNetworkError: 500 Internal Server Error, connection reset

The retry loop in copyImage() now calls IsRetryableError() instead of IsECRRateLimitError() directly, and the log message includes the actual error for easier debugging.

Fixes #1328